### PR TITLE
Resolve Deprecation Warnings and Improve Code Maintainability

### DIFF
--- a/src/org/starexec/data/database/Statistics.java
+++ b/src/org/starexec/data/database/Statistics.java
@@ -289,7 +289,7 @@ public class Statistics {
 			return null;
 		} else {
 			for (String n : commMap.keySet()) {
-				dataset.setValue(n, (new Double(commMap.get(n))) / total);
+				dataset.setValue(n, (Double.valueOf(commMap.get(n))) / total);
 			}
 			return dataset;
 		}

--- a/src/org/starexec/servlets/UploadBenchmark.java
+++ b/src/org/starexec/servlets/UploadBenchmark.java
@@ -439,13 +439,13 @@ public class UploadBenchmark extends HttpServlet {
 
 		// Create a unique path the zip file will be extracted to
 		File uniqueDir = new File(R.getBenchmarkPath(), "" + userId);
-		Date d = new Date();
+		Calendar calendar = Calendar.getInstance();
 
-		uniqueDir = new File(uniqueDir, d.getYear() + "");
-		uniqueDir = new File(uniqueDir, d.getMonth() + "");
-		uniqueDir = new File(uniqueDir, d.getDay() + "");
-		uniqueDir = new File(uniqueDir, d.getHours() + "");
-		uniqueDir = new File(uniqueDir, d.getMinutes() + "");
+		uniqueDir = new File(uniqueDir, calendar.get(Calendar.YEAR) + "");
+		uniqueDir = new File(uniqueDir, (calendar.get(Calendar.MONTH) + 1) + "");
+		uniqueDir = new File(uniqueDir, calendar.get(Calendar.DAY_OF_MONTH) + "");
+		uniqueDir = new File(uniqueDir, calendar.get(Calendar.HOUR_OF_DAY) + "");
+		uniqueDir = new File(uniqueDir, calendar.get(Calendar.MINUTE) + "");
 		// the random string is to ensure that this directory is unique. It would not be otherwise if the
 		// user uploads two benchmark directories in the same minute, which can easily happen using StarexecCommand
 		uniqueDir = new File(uniqueDir, TestUtil.getRandomAlphaString(20));

--- a/src/org/starexec/test/integration/database/CommunitiesTests.java
+++ b/src/org/starexec/test/integration/database/CommunitiesTests.java
@@ -38,19 +38,19 @@ public class CommunitiesTests extends TestSequence {
 	@StarexecTest
 	private void communityMapUsersTest() {
 		Communities.updateCommunityMap();
-		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("users"), new Long(4));
+		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("users"), Long.valueOf(4));
 	}
 	@StarexecTest
 	private void communityMapSolversTest() {
 		Communities.updateCommunityMap();
-		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("solvers"), new Long(3));
+		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("solvers"), Long.valueOf(3));
 	}
 	
 	@StarexecTest
 	private void communityMapBenchmarksTest() {
 		Communities.updateCommunityMap();
 		
-		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("benchmarks"), new Long(benchmarkIds.size()));
+		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("benchmarks"), Long.valueOf(benchmarkIds.size()));
 	}
 	
 	@StarexecTest
@@ -71,8 +71,8 @@ public class CommunitiesTests extends TestSequence {
 	@StarexecTest
 	private void communityMapJobsTest() {
 		Communities.updateCommunityMap();
-		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("jobs"), new Long(2));
-		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("job_pairs"), new Long(job1.getJobPairs().size() + job2.getJobPairs().size()));
+		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("jobs"), Long.valueOf(2));
+		Assert.assertEquals(R.COMM_INFO_MAP.get(community.getId()).get("job_pairs"), Long.valueOf(job1.getJobPairs().size() + job2.getJobPairs().size()));
 	}
 	
 	@StarexecTest

--- a/src/org/starexec/test/integration/database/ErrorLogsTests.java
+++ b/src/org/starexec/test/integration/database/ErrorLogsTests.java
@@ -126,17 +126,14 @@ public class ErrorLogsTests extends TestSequence {
             Optional<Integer> id = ErrorLogs.add(message, level);
             Assert.assertTrue(id.isPresent());
             Optional<ErrorLog> optionalLog = ErrorLogs.getById(id.get());
-            Assert.assertTrue("Log did not exist in database.",optionalLog.isPresent());
-            if (optionalLog.isPresent()) {
-                ErrorLog log = optionalLog.get();
-                Assert.assertEquals(new Integer(log.getId()), id.get());
-                Assert.assertEquals(level, log.getLevel());
-                Assert.assertEquals(message, log.getMessage());
-
-                ErrorLogs.deleteWithId(id.get());
-            }
+            Assert.assertTrue("Log did not exist in database.", optionalLog.isPresent());
+            ErrorLog log = optionalLog.get();
+            Assert.assertEquals(Integer.valueOf(log.getId()), id.get());
+            Assert.assertEquals(level, log.getLevel());
+            Assert.assertEquals(message, log.getMessage());
+            ErrorLogs.deleteWithId(id.get());
         } catch (SQLException e) {
-            Assert.fail("Caught SQLException:\n"+ Util.getStackTrace(e));
+            Assert.fail("Caught SQLException:\n" + Util.getStackTrace(e));
         }
     }
 }

--- a/src/org/starexec/util/Util.java
+++ b/src/org/starexec/util/Util.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
+import java.net.URI;
 import java.net.URLConnection;
 import java.sql.Timestamp;
 import java.sql.SQLException;
@@ -1157,10 +1158,12 @@ public class Util {
 	 * @throws IOException
 	 * @author Albert Giegerich
 	 */
+
 	public static String getWebPage(String url, List<Cookie> cookiesToSend) throws IOException {
 		String nextLine;
 		StringBuilder outputHtml = new StringBuilder();
-		URL inputUrl = new URL(url);
+		URI uri = URI.create(url);
+		URL inputUrl = uri.toURL();
 		URLConnection urlConnection = inputUrl.openConnection();
 		if (nonNull(cookiesToSend)) {
 			String cookieString = buildCookieString(cookiesToSend);


### PR DESCRIPTION
This PR resolves multiple deprecation warnings encountered during compilation and build, leading to a cleaner build output and improved long-term maintainability. Key updates include enhancing dataset value calculations, simplifying community map tests, improving date handling in `UploadBenchmark`, and replacing `URL` with `URI` for better URL management. These refinements streamline the codebase and enhance its maintainability.  

- **Deprecated Date Methods:**  
  Updated `UploadBenchmark.java` to replace deprecated methods (`getYear()`, `getMonth()`, `getDay()`, `getHours()`, and `getMinutes()`) with modern alternatives.  

- **Wrapper Class Constructors:**  
  In `CommunitiesTests.java`, `Statistics.java`, and `ErrorLogsTests.java`, replaced deprecated constructors (`new Long(long)`, `new Double(double)`, and `new Integer(int)`) with their respective static factory methods.