### PR TITLE
Fix ResultSet iteration in Permissions.get() method

### DIFF
--- a/src/org/starexec/data/database/Permissions.java
+++ b/src/org/starexec/data/database/Permissions.java
@@ -414,7 +414,7 @@ public class Permissions {
 			procedure.setInt(2, spaceId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				Permission p = resultsToPermissionWithId(userId, results);
 				if (results.wasNull()) {
 					/* If the permission doesn't exist we always get a result


### PR DESCRIPTION
Replace `results.first()` with `results.next()` to ensure reliable retrieval of permission data and prevent potential errors with forward-only ResultSets.