### PR TITLE
Replace `first()` with `next()` for result iteration consistency

### DIFF
--- a/src/org/starexec/data/database/Logins.java
+++ b/src/org/starexec/data/database/Logins.java
@@ -21,7 +21,7 @@ public class Logins {
 					"{CALL GetNumberOfUniqueLogins()}",
 					p -> {},
 					results -> {
-						results.first();
+						results.next();
 						return results.getInt(1);
 					}
 			);

--- a/src/org/starexec/data/database/Permissions.java
+++ b/src/org/starexec/data/database/Permissions.java
@@ -92,7 +92,7 @@ public class Permissions {
 			procedure.setInt(2, userId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				return results.getBoolean(1);
 			}
 		} catch (Exception e) {
@@ -202,7 +202,7 @@ public class Permissions {
 			procedure.setInt(2, userId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				boolean userCanSeeJob = results.getBoolean(1);
 				if (userCanSeeJob) {
 					log.debug(methodName, "User can see job.");
@@ -260,7 +260,7 @@ public class Permissions {
 			procedure.setInt(2, userId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				return results.getBoolean(1);
 			}
 		} catch (Exception e) {
@@ -360,7 +360,7 @@ public class Permissions {
 			procedure.setInt(2, userId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				return results.getBoolean(1);
 			}
 		} catch (Exception e) {
@@ -414,7 +414,7 @@ public class Permissions {
 			procedure.setInt(2, spaceId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				Permission p = resultsToPermissionWithId(userId, results);
 				if (results.wasNull()) {
 					/* If the permission doesn't exist we always get a result
@@ -510,7 +510,7 @@ public class Permissions {
 			procedure.setInt(1, spaceId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				return resultsToPermissionWithId(results.getInt("id"), results);
 			}
 		} catch (Exception e) {

--- a/src/org/starexec/data/database/Requests.java
+++ b/src/org/starexec/data/database/Requests.java
@@ -543,9 +543,14 @@ public class Requests {
 
 			// There should only be 1 result since the user id is the primary
 			// key.
-			results.next();
-			newEmail = results.getString("new_email");
-			emailChangeCodeAssociatedWithUser = results.getString("code");
+			if (results.next()) {
+				newEmail = results.getString("new_email");
+				emailChangeCodeAssociatedWithUser = results.getString("code");
+			} else {
+				throw new StarExecDatabaseException(
+					"No change email request found for user with id=" + userId + "."
+				);
+			}
 		} catch (Exception e) {
 			throw new StarExecDatabaseException(
 					"There was an error while trying to get a change email request for user with id=" + userId + ".",

--- a/src/org/starexec/data/database/Requests.java
+++ b/src/org/starexec/data/database/Requests.java
@@ -543,7 +543,7 @@ public class Requests {
 
 			// There should only be 1 result since the user id is the primary
 			// key.
-			results.first();
+			results.next();
 			newEmail = results.getString("new_email");
 			emailChangeCodeAssociatedWithUser = results.getString("code");
 		} catch (Exception e) {

--- a/src/org/starexec/data/database/Spaces.java
+++ b/src/org/starexec/data/database/Spaces.java
@@ -1894,7 +1894,7 @@ public class Spaces {
 			procedure.setInt(1, spaceId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				return results.getBoolean("public");
 			}
 		} catch (Exception e) {
@@ -1924,7 +1924,7 @@ public class Spaces {
 			procedure.setInt(1, spaceId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				return (results.getInt(1) > 0);
 			}
 		} catch (Exception e) {

--- a/src/org/starexec/data/database/Statistics.java
+++ b/src/org/starexec/data/database/Statistics.java
@@ -175,7 +175,7 @@ public class Statistics {
 			procedure.setInt(1, jobId);
 			results = procedure.executeQuery();
 
-			if (results.first()) {
+			if (results.next()) {
 				return Statistics.getMapFromResult(results);
 			}
 


### PR DESCRIPTION
Update database query result handling to use `next()` for improved consistency and correctness across multiple utility classes, aligning with standard JDBC practices.