### PR TITLE
Add missing pathelement for javax.activation JAR in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -24,6 +24,7 @@
 		<fileset dir="${web-inf}/lib" includes="**/*.jar"/>
 		<fileset dir="${tomcat-dir}/lib" includes="**/*.jar"/>
 		<fileset dir="local-lib" includes="**/*.jar"/>
+		<pathelement location="${web-inf}/lib/javax.activation-1.2.0.jar"/>
 	</path>
 	<path id="starcomclasspath">
 		<fileset dir="${starcomlib}" includes="**/*.jar"/>


### PR DESCRIPTION
Include the javax.activation JAR in the build path to ensure proper functionality.