### PR TITLE
Enhance MySQL connection security

### DIFF
--- a/src/org/starexec/data/database/Common.java
+++ b/src/org/starexec/data/database/Common.java
@@ -28,7 +28,7 @@ public class Common {
 	private static int connectionsDrift  = 0;
 
 	//args to append to the mysql URL.
-	private static final String MYSQL_URL_ARGUMENTS = "?autoReconnect=true&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true";
+	private static final String MYSQL_URL_ARGUMENTS = "?noAccessToProcedureBodies=true&autoReconnect=true&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true";
 
 	/**
 	 * Creates a new historical record in the logins table which keeps track of all user logins.


### PR DESCRIPTION
Update MySQL URL arguments to improve connection security by adding `noAccessToProcedureBodies=true`, which restricts access to stored procedure bodies and mitigates potential risks in database interactions.