### PR TITLE
fix: normalize node names in GridEngine backend

### DIFF
--- a/src/org/starexec/backend/GridEngineBackend.java
+++ b/src/org/starexec/backend/GridEngineBackend.java
@@ -217,7 +217,14 @@ public class GridEngineBackend implements Backend{
     		String nodeResults = Util.executeCommand(NODE_LIST_COMMAND);
     		log.trace("getWorkerNodes got the following results");
     		log.trace(nodeResults);
-    		return nodeResults.split(System.getProperty("line.separator"));
+    		String[] lines = nodeResults.split(System.getProperty("line.separator"));
+    		// Normalize node names: take first part before dot (handle FQDNs)
+    		for (int i = 0; i < lines.length; i++) {
+    			if (lines[i] != null && !lines[i].isEmpty()) {
+    				lines[i] = lines[i].split("\\.")[0];
+    			}
+    		}
+    		return lines;
     	} catch (Exception e) {
     		log.error(e.getMessage(),e);
     	} finally {
@@ -267,7 +274,9 @@ public class GridEngineBackend implements Backend{
     		while(matcher.find()) {
     			// Split apart the key from the value
     			String[] queueNode = matcher.group().split("@");
-    			nodesToQueuesMap.put(queueNode[1], queueNode[0]);
+    			// Normalize node name: take first part before dot (handle FQDNs)
+    			String nodeName = queueNode[1].split("\\.")[0];
+    			nodesToQueuesMap.put(nodeName, queueNode[0]);
     		}
 
     		return nodesToQueuesMap;


### PR DESCRIPTION
## Summary
Normalize node names by taking first part before dot (handle FQDNs) in `getWorkerNodes` and `getNodeQueueAssociations` methods.

## Changes
- `GridEngineBackend.getWorkerNodes()`: Split node names on dot to extract short hostname
- `GridEngineBackend.getNodeQueueAssociations()`: Normalize node names before mapping to queues

## Why this is needed
When SGE returns fully qualified domain names (FQDNs) for nodes, the backend previously stored the full FQDN in the database. This could cause inconsistencies when comparing node names across different backend methods (e.g., when associating nodes with queues). Normalizing to the short hostname ensures consistent representation throughout the system.

## Impact
- Node names stored in the database will now be short hostnames (without domain)
- Existing node associations remain valid (queue associations use normalized names)
- No changes required for other backend implementations (OAR, Kubernetes, Local)

## Testing Considerations
- Manual verification that node names are correctly normalized in cluster administration UI
- Ensure queue-node associations are correctly loaded and displayed
- Existing integration tests should pass (no functional changes to public API)