### PR TITLE
fix(sql): refine job pair terminal status codes and completion logic

### DIFF
--- a/sql/procedures/JobPairs.sql
+++ b/sql/procedures/JobPairs.sql
@@ -4,9 +4,7 @@
 DROP PROCEDURE IF EXISTS UpdateJobPairStatus //
 CREATE PROCEDURE UpdateJobPairStatus(IN _pairId INT, IN _statusCode INT)
 	BEGIN
-		UPDATE job_pairs
-		SET status_code = _statusCode
-		WHERE id = _pairId;
+		CALL UpdatePairStatus(_pairId, _statusCode);
 	END //
 
 DROP PROCEDURE IF EXISTS UpdateJobSpaceId //
@@ -114,12 +112,21 @@ DROP PROCEDURE IF EXISTS UpdatePairStatus //
 CREATE PROCEDURE UpdatePairStatus(IN _jobPairId INT, IN _statusCode TINYINT)
 	BEGIN
 		UPDATE job_pairs SET status_code=_statusCode WHERE id=_jobPairId ;
-		IF (_statusCode>6 AND _statusCode<19) THEN
+		-- List of terminal status codes (ones that mean the pair is finished and won't be updated further)
+		-- 7-18: Normal completion, resource limits, and common errors
+		-- 21: Killed
+		-- 23: Not reached
+		-- 24: Benchmark dependency missing
+		-- 25: Pre-processor error
+		-- 26: Post-processor error
+		IF ((_statusCode>6 AND _statusCode<19) OR _statusCode IN (21, 23, 24, 25, 26)) THEN
 			REPLACE INTO job_pair_completion (pair_id) VALUES (_jobPairId);
 
 			-- this checks to see if the job is done and sets its completion id if so.
 			-- It checks by trying to find exactly 1 pair (for efficiency) that is not yet complete
-			IF (SELECT COUNT(*) FROM (select id from job_pairs WHERE job_id=(SELECT job_id FROM job_pairs WHERE job_pairs.id=_jobPairId) AND (status_code<7 || status_code>18) LIMIT 1) as theCount)=0 THEN
+			-- A pair is "not yet complete" if its status is Pending (1), Enqueued (2), Running (4), 
+			-- Processing Results (19), Paused (20), or Awaiting post-processor (22).
+			IF (SELECT COUNT(*) FROM (SELECT id FROM job_pairs WHERE job_id=(SELECT job_id FROM job_pairs WHERE job_pairs.id=_jobPairId) AND (status_code IN (1, 2, 4, 19, 20, 22)) LIMIT 1) as theCount)=0 THEN
 				UPDATE jobs SET completed=CURRENT_TIMESTAMP WHERE id=(SELECT job_id FROM job_pairs WHERE job_pairs.id=_jobPairId);
 			END IF;
 		END IF;

--- a/sql/procedures/Jobs.sql
+++ b/sql/procedures/Jobs.sql
@@ -208,8 +208,8 @@ CREATE PROCEDURE GetJobPairOverview(IN _jobId INT)
 		SELECT * FROM (
 			(SELECT total_pairs AS totalPairs FROM jobs WHERE id=_jobId) AS a, -- Gets the total number of pairs
 			(SELECT COUNT(*) AS completePairs FROM job_pairs WHERE job_id=_jobId AND status_code=7) AS b, -- Gets number of pairs with COMPLETE status codes
-			(SELECT COUNT(*) AS pendingPairs FROM job_pairs WHERE job_id=_jobId AND (status_code BETWEEN 1 AND 6 OR status_code=22)) AS c, -- Gets number of pairs with non complete and non error status codes
-			(SELECT COUNT(*) AS errorPairs FROM job_pairs WHERE job_id=_jobId AND (status_code BETWEEN 8 AND 17 OR status_code=0)) AS d, -- Gets number of UNKNOWN or ERROR status code pairs
+			(SELECT COUNT(*) AS pendingPairs FROM job_pairs WHERE job_id=_jobId AND (status_code BETWEEN 1 AND 6 OR status_code=22 OR status_code=19)) AS c, -- Gets number of pairs with non complete and non error status codes
+			(SELECT COUNT(*) AS errorPairs FROM job_pairs WHERE job_id=_jobId AND (status_code BETWEEN 8 AND 17 OR status_code=0 OR status_code BETWEEN 24 AND 26)) AS d, -- Gets number of UNKNOWN or ERROR status code pairs
 			(SELECT TIMESTAMPDIFF( -- Gets time difference between earliest completed pair's start time and latest completed pair's end time
 				MICROSECOND,
 				(SELECT MIN(start_time) FROM job_pairs WHERE job_id=_jobId AND status_code=7),
@@ -763,7 +763,7 @@ CREATE PROCEDURE GetQueueJobsById(IN _queueId INT)
 			(SELECT distinct job_id FROM job_pairs WHERE status_code BETWEEN 1 AND 6)
 		  AND NOT paused
 		  AND NOT killed
-		ORDER BY created DESC;
+		  ORDER BY created DESC;
 	END //
 
 -- Returns the number of jobs in the entire system


### PR DESCRIPTION
- Updated `UpdatePairStatus` in JobPairs.sql to include additional terminal status codes (21, 23-26) in the completion check.
- Refined the "job done" check to explicitly look for non-terminal statuses (Pending, Enqueued, Running, Processing, Paused, Awaiting post-processor).
- Updated `GetJobPairOverview` in Jobs.sql to sync pending and error pair counts with the expanded status code list.
- Centralized job pair status updates by making `UpdateJobPairStatus` call `UpdatePairStatus`.