### PR TITLE
fix: correct wrong success/error messages across REST endpoints and servlets (#85)

### DIFF
--- a/starexec-app/src/main/java/org/starexec/app/RESTServices.java
+++ b/starexec-app/src/main/java/org/starexec/app/RESTServices.java
@@ -3795,7 +3795,8 @@ public class RESTServices {
 		try {
 			boolean success = Settings.deleteProfile(id);
 			// Passed validation AND Database update successful
-			return success ? gson.toJson(new ValidatorStatusCode(true, "Community edit successful"))
+			// Fix: was "Community edit successful" — see GitHub issue #85 audit
+			return success ? gson.toJson(new ValidatorStatusCode(true, "Default settings profile deleted successfully"))
 					: gson.toJson(ERROR_DATABASE);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
@@ -3966,7 +3967,8 @@ public class RESTServices {
 			}
 
 			// Passed validation AND Database update successful
-			return success ? gson.toJson(new ValidatorStatusCode(true, "Community edit successful"))
+			// Fix: was "Community edit successful" — see GitHub issue #85 audit
+			return success ? gson.toJson(new ValidatorStatusCode(true, "Default settings updated successfully"))
 					: gson.toJson(ERROR_DATABASE);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
@@ -4217,7 +4219,8 @@ public class RESTServices {
 		if (!Solvers.restoreRecycledSolvers(userId)) {
 			return gson.toJson(ERROR_DATABASE);
 		}
-		return gson.toJson(new ValidatorStatusCode(true, "Solvers restored successfully"));
+		// Fix: was "Solvers restored successfully" — see GitHub issue #85 audit
+		return gson.toJson(new ValidatorStatusCode(true, "Solvers deleted successfully"));
 	}
 
 	/**
@@ -4604,7 +4607,8 @@ public class RESTServices {
 			return gson.toJson(status);
 		}
 		return Users.associate(selectedUsers, spaceId, copyToSubspaces, requestUserId)
-				? gson.toJson(new ValidatorStatusCode(true, "User(s) moved successfully"))
+				// Fix: was "User(s) moved successfully" — see GitHub issue #85 audit
+				? gson.toJson(new ValidatorStatusCode(true, "User(s) added successfully"))
 				: gson.toJson(ERROR_DATABASE);
 	}
 
@@ -4687,7 +4691,9 @@ public class RESTServices {
 			// if we did a copy, the solvers are already associated with the root space, so
 			// we don't need to link to that one
 			return Solvers.associate(selectedSolvers, spaceId, copyToSubspaces, requestUserId, !copy)
-					? gson.toJson(new ValidatorStatusCode(true, "Solver(s) moved successfully"))
+					// Fix: was "Solver(s) moved successfully" — see GitHub issue #85 audit
+					? gson.toJson(new ValidatorStatusCode(true,
+							copy ? "Solver(s) copied successfully" : "Solver(s) linked successfully"))
 					: gson.toJson(ERROR_DATABASE);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
@@ -4829,7 +4835,8 @@ public class RESTServices {
 		boolean success = Jobs.associate(selectedJobs, spaceId);
 
 		// Return a value based on results from database operation
-		return success ? gson.toJson(new ValidatorStatusCode(true, "Job(s) moved successfully"))
+		// Fix: was "Job(s) moved successfully" — see GitHub issue #85 audit
+		return success ? gson.toJson(new ValidatorStatusCode(true, "Job(s) added successfully"))
 				: gson.toJson(ERROR_DATABASE);
 	}
 
@@ -5533,7 +5540,8 @@ public class RESTServices {
 			}
 		};
 		Util.threadPoolExecute(removeSubspacesProcess);
-		return gson.toJson(new ValidatorStatusCode(true, "Subspaces are being deleted."));
+		// Fix: was "Subspaces are being deleted." — see GitHub issue #85 audit
+		return gson.toJson(new ValidatorStatusCode(true, "Subspaces are being removed."));
 	}
 
 	/**
@@ -7359,7 +7367,8 @@ public class RESTServices {
 		log.debug("made it into readOnly API CALL readOnly: " + readOnly);
 		int userId = SessionUtil.getUserId(request);
 		if (!GeneralSecurity.hasAdminWritePrivileges(userId)) {
-			return gson.toJson(new ValidatorStatusCode(true, "Only Admins can set read only"));
+			// Fix: was success=true with admin permission failure — see GitHub issue #85 audit
+			return gson.toJson(new ValidatorStatusCode(false, "Only admins can set read only mode."));
 		}
 		try {
 			RESTHelpers.setReadOnly(readOnly);
@@ -7381,7 +7390,8 @@ public class RESTServices {
 	public String freezePrimitives(@FormParam("frozen") boolean frozen, @Context HttpServletRequest request) {
 		int userId = SessionUtil.getUserId(request);
 		if (!GeneralSecurity.hasAdminWritePrivileges(userId)) {
-			return gson.toJson(new ValidatorStatusCode(true, "Only Admins can freeze or unfreeze primitives"));
+			// Fix: was success=true with admin permission failure — see GitHub issue #85 audit
+			return gson.toJson(new ValidatorStatusCode(false, "Only admins can freeze or unfreeze primitives."));
 		}
 		try {
 			RESTHelpers.setFreezePrimitives(frozen);

--- a/starexec-app/src/main/java/org/starexec/servlets/ProcessorManager.java
+++ b/starexec-app/src/main/java/org/starexec/servlets/ProcessorManager.java
@@ -371,7 +371,7 @@ public class ProcessorManager extends HttpServlet {
 			log.warn(e.getMessage(), e);
 		}
 
-		// Return false control flow is broken and ends up here
-		return new ValidatorStatusCode(true, "Internal error processing request");
+		// Fix: was success=true for an internal error path — see GitHub issue #85 audit
+		return new ValidatorStatusCode(false, "Internal error processing request.");
 	}
 }

--- a/starexec-app/src/main/java/org/starexec/servlets/Registration.java
+++ b/starexec-app/src/main/java/org/starexec/servlets/Registration.java
@@ -247,10 +247,11 @@ public class Registration extends HttpServlet {
 					log.warn("Failed to create personal subspace for user " + user.getEmail(), e);
 					// Don't fail the registration if personal space creation fails
 				}
-						try {
+			try {
 				Mail.sendPassword(user, request.getParameter(Registration.USER_PASSWORD));
 			} catch (Exception e) {
 				log.warn("Failed to send password email to user " + user.getEmail(), e);
+				// Fix: keep success=true because account creation succeeded and only follow-up email delivery failed — see GitHub issue #85 audit
 				return new ValidatorStatusCode(true, "email_failed");
 			}
 				return new ValidatorStatusCode(true);
@@ -273,6 +274,7 @@ public class Registration extends HttpServlet {
 					Mail.sendActivationCode(user, code);
 				} catch (Exception e) {
 					log.warn("Failed to send activation email to user " + user.getEmail(), e);
+					// Fix: keep success=true because registration succeeded and only follow-up email delivery failed — see GitHub issue #85 audit
 					return new ValidatorStatusCode(true, "email_failed");
 				}
 				return new ValidatorStatusCode(true);

--- a/starexec-app/src/main/java/org/starexec/servlets/Verify.java
+++ b/starexec-app/src/main/java/org/starexec/servlets/Verify.java
@@ -117,6 +117,7 @@ public class Verify extends HttpServlet {
 		}
 
 		String status = "";
+		boolean success = true;
 		switch (verdict) {
 		case Web.APPROVE_COMMUNITY_REQUEST:
 			try {
@@ -125,6 +126,8 @@ public class Verify extends HttpServlet {
 			} catch (StarExecException e) {
 				log.error("Failed to approve community request", e);
 				status = "Failed to approve the user.";
+				// Fix: was success=true for failed approval branch — see GitHub issue #85 audit
+				success = false;
 			}
 			break;
 		case Web.DECLINE_COMMUNITY_REQUEST:
@@ -136,7 +139,7 @@ public class Verify extends HttpServlet {
 		if (sentFromCommunityPage) {
 			response.setContentType("application/json");
 			response.getWriter()
-			        .write(gson.toJson(new ValidatorStatusCode(true, status)));
+			        .write(gson.toJson(new ValidatorStatusCode(success, status)));
 		} else {
 			response.sendRedirect(Util.docRoot("public/messages/leader_response.jsp"));
 		}


### PR DESCRIPTION
## Summary

Full audit and fix of wrong success message strings and incorrect
`ValidatorStatusCode(true, ...)` usage on error paths, triggered by issue #85.

## Root cause (issue #85)

`RESTServices.java:4258` — the `/deleterecycled/solvers` endpoint returned
`"Solvers restored successfully"` due to a copy-paste error from the adjacent
restore endpoint. The frontend displays whatever message the server returns, so
the green banner was semantically wrong.

## Scope of audit

All `ValidatorStatusCode` instantiations across `RESTServices.java`,
`ProcessorManager.java`, `Verify.java`, and `Registration.java` were reviewed
against their enclosing endpoint action and HTTP path.

## Changes

### Message mismatch fixes

| File | Path | Was | Now |
|------|------|-----|-----|
| RESTServices.java:4258 | `/deleterecycled/solvers` | "Solvers restored successfully" | "Solvers deleted successfully" |
| RESTServices.java:3798 | `/delete/defaultSettings/{id}` | "Community edit successful" | "Default settings profile deleted successfully" |
| RESTServices.java:3969 | `/edit/defaultSettings/{attr}/{id}` | "Community edit successful" | "Default settings updated successfully" |
| RESTServices.java:4607 | `/spaces/{spaceId}/add/user` | "User(s) moved successfully" | "User(s) added successfully" |
| RESTServices.java:4690 | `/spaces/{spaceId}/add/solver` | "Solver(s) moved successfully" | "Solver(s) copied/linked successfully" (branched) |
| RESTServices.java:4832 | `/spaces/{spaceId}/add/job` | "Job(s) moved successfully" | "Job(s) added successfully" |
| RESTServices.java:5536 | `/remove/subspace` | "Subspaces are being deleted." | "Subspaces are being removed." |

### Success=true on error path fixes

| File | Context | Fix |
|------|---------|-----|
| RESTServices.java:7362 | `/admin/readOnly` permission failure | `true` → `false` |
| RESTServices.java:7384 | `/admin/freezePrimitives` permission failure | `true` → `false` |
| ProcessorManager.java:375 | Internal error fallthrough | `true` → `false` |
| Verify.java:139 | "Failed to approve the user." branch | `true` → `false` |

### Intentionally unchanged

`Registration.java` `email_failed` paths retain `success=true` because account
creation succeeded — only the follow-up email delivery failed. An explanatory
comment has been added to both sites.

## Testing

- Re-grepped `ValidatorStatusCode(true` across all Java after patching.
- Re-grepped `"moved successfully"`, `"Community edit successful"`,
  `"restored successfully"` — no remaining mismatched usages.
- No JS/JSP hardcoded success strings were found to be mismatched.

## References

Closes #85
