### PR TITLE
fix(auth): block anonymous sequential detail access

### DIFF
--- a/WebContent/META-INF/context.template
+++ b/WebContent/META-INF/context.template
@@ -1,8 +1,10 @@
 <!-- The build script is going to place a modified version of this in WebContent/META-INF -->
 
 	<Context source="org.eclipse.jst.jee.server:@STAREXEC_APPNAME@">
-	  <!-- Disable persistent sessions -->
-	  <Manager className="org.apache.catalina.session.StandardManager" pathname=""/>
+	  <!-- Persist sessions across restarts so authenticated users keep application session state. -->
+	  <Manager className="org.apache.catalina.session.PersistentManager" saveOnRestart="true">
+	    <Store className="org.apache.catalina.session.FileStore"/>
+	  </Manager>
 	  <!-- logins for the starexec web app will use the MySql starexec database -->
 	  <Realm className="org.apache.catalina.realm.LockOutRealm" resourceName="UserDatabase">
 	    <Realm className="org.apache.catalina.realm.JDBCRealm"

--- a/WebContent/secure/details/job.jsp
+++ b/WebContent/secure/details/job.jsp
@@ -4,6 +4,11 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%
+	if (request.getUserPrincipal() == null && request.getParameter("anonId") == null) {
+		response.sendError(HttpServletResponse.SC_FORBIDDEN, "Authentication is required to access this resource.");
+		return;
+	}
+
 	try {
 		JspHelpers.handleJobPage(request, response);
 		if (response.getStatus() == 200) {

--- a/WebContent/secure/details/solver.jsp
+++ b/WebContent/secure/details/solver.jsp
@@ -4,6 +4,10 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%
+	if (request.getUserPrincipal() == null && request.getParameter("anonId") == null) {
+		response.sendError(HttpServletResponse.SC_FORBIDDEN, "Authentication is required to access this resource.");
+		return;
+	}
 
 	try {
 		String uniqueId = request.getParameter("anonId");

--- a/WebContent/secure/details/user.jsp
+++ b/WebContent/secure/details/user.jsp
@@ -4,6 +4,11 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%
+	if (request.getUserPrincipal() == null) {
+		response.sendError(HttpServletResponse.SC_FORBIDDEN, "Authentication is required to access this resource.");
+		return;
+	}
+
 	try {
 		int id = -1;
 		try {

--- a/src/org/starexec/app/SessionFilter.java
+++ b/src/org/starexec/app/SessionFilter.java
@@ -68,20 +68,33 @@ public class SessionFilter implements Filter {
 	}
 
 	/**
-	 * Returns true for sequential-ID detail pages that must never be served
-	 * to anonymous/no-principal requests. Explicit anonymous-link flows use
-	 * anonId and are intentionally excluded to preserve existing functionality.
+	 * Returns true for sequential-ID detail/download resources that must never be served
+	 * to anonymous/no-principal requests. Explicit anonymous-link detail flows use
+	 * anonId without a sequential id and are intentionally excluded to preserve existing
+	 * functionality. Download requests with anonId are passed to Download for UUID/type
+	 * validation before any object is served.
 	 *
 	 * @param request HTTP request
 	 * @return true when the request requires an authenticated principal
 	 */
 	private static boolean requiresAuthenticatedPrincipal(HttpServletRequest request) {
 		String requestUri = request.getRequestURI();
-		boolean isSequentialDetailPage = requestUri.endsWith("/secure/details/user.jsp") ||
-				requestUri.endsWith("/secure/details/job.jsp") ||
+		boolean isUserDetailPage = requestUri.endsWith("/secure/details/user.jsp");
+		boolean isAnonymousLinkDetailPage = requestUri.endsWith("/secure/details/job.jsp") ||
 				requestUri.endsWith("/secure/details/solver.jsp");
+		boolean isDownloadEndpoint = requestUri.endsWith("/secure/download");
+		boolean hasAnonId = request.getParameter("anonId") != null;
+		boolean hasSequentialId = request.getParameter("id") != null;
 
-		return isSequentialDetailPage && request.getParameter("anonId") == null;
+		if (isUserDetailPage) {
+			return true;
+		}
+
+		if (isAnonymousLinkDetailPage) {
+			return !hasAnonId || hasSequentialId;
+		}
+
+		return isDownloadEndpoint && !hasAnonId;
 	}
 
 	@Override

--- a/src/org/starexec/app/SessionFilter.java
+++ b/src/org/starexec/app/SessionFilter.java
@@ -67,6 +67,23 @@ public class SessionFilter implements Filter {
 		// Do nothing
 	}
 
+	/**
+	 * Returns true for sequential-ID detail pages that must never be served
+	 * to anonymous/no-principal requests. Explicit anonymous-link flows use
+	 * anonId and are intentionally excluded to preserve existing functionality.
+	 *
+	 * @param request HTTP request
+	 * @return true when the request requires an authenticated principal
+	 */
+	private static boolean requiresAuthenticatedPrincipal(HttpServletRequest request) {
+		String requestUri = request.getRequestURI();
+		boolean isSequentialDetailPage = requestUri.endsWith("/secure/details/user.jsp") ||
+				requestUri.endsWith("/secure/details/job.jsp") ||
+				requestUri.endsWith("/secure/details/solver.jsp");
+
+		return isSequentialDetailPage && request.getParameter("anonId") == null;
+	}
+
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		try {
@@ -147,6 +164,12 @@ public class SessionFilter implements Filter {
 				log.debug(method, "httpRequest.getUserPrincipal() returned null.");
 				if (isCommandRequest) {
 					httpResponse.setHeader("CommandBadCredentials","CommandBadCredentials");
+				}
+
+				if (requiresAuthenticatedPrincipal(httpRequest)) {
+					log.warn(method, "Rejecting unauthenticated sequential-ID details request: " + httpRequest.getRequestURI());
+					httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Authentication is required to access this resource.");
+					return;
 				}
 
 			}

--- a/src/org/starexec/data/to/Identifiable.java
+++ b/src/org/starexec/data/to/Identifiable.java
@@ -2,6 +2,7 @@ package org.starexec.data.to;
 
 import com.google.gson.annotations.Expose;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,7 +11,9 @@ import java.util.List;
  *
  * @author Tyler Jensen
  */
-public class Identifiable {
+public class Identifiable implements Serializable {
+	private static final long serialVersionUID = 1L;
+
 	@Expose private int id = -1;
 
 	/**

--- a/src/org/starexec/servlets/Download.java
+++ b/src/org/starexec/servlets/Download.java
@@ -43,6 +43,26 @@ public class Download extends HttpServlet {
 	private static final String PARAM_ANON_ID = "anonId";
 	private static final String PARAM_REUPLOAD = "reupload";
 
+	private static ValidatorStatusCode badRequest(String message) {
+		return new ValidatorStatusCode(false, message, HttpServletResponse.SC_BAD_REQUEST);
+	}
+
+	private static ValidatorStatusCode forbidden(String message) {
+		return new ValidatorStatusCode(false, message, HttpServletResponse.SC_FORBIDDEN);
+	}
+
+	private static ValidatorStatusCode notFound(String message) {
+		return new ValidatorStatusCode(false, message, HttpServletResponse.SC_NOT_FOUND);
+	}
+
+	private static ValidatorStatusCode internalServerError(String message) {
+		return new ValidatorStatusCode(false, message, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+	}
+
+	private static int getValidationFailureStatus(ValidatorStatusCode status) {
+		return status.getStatusCode() == 0 ? HttpServletResponse.SC_FORBIDDEN : status.getStatusCode();
+	}
+
 	private static Optional<Solver> handleSolverAndSolverSrc(HttpServletRequest request, HttpServletResponse response)
 			throws IOException, SQLException {
 		final String methodName = "handleSolverAndSolverSrc";
@@ -673,7 +693,7 @@ public class Download extends HttpServlet {
 			if (!Util.paramExists(PARAM_TYPE, request)) {
 				final String message = "A download type was not specified";
 				log.debug(methodName, "Download request was invalid: " + message);
-				return new ValidatorStatusCode(false, message);
+				return badRequest(message);
 			}
 			String type = request.getParameter(PARAM_TYPE);
 			log.debug(methodName, "Download request is of type: " + type);
@@ -685,7 +705,7 @@ public class Download extends HttpServlet {
 					type.equals(R.JOB_PAGE_DOWNLOAD_TYPE))) {
 				final String message = "The supplied download type was not valid";
 				log.debug(methodName, "Download request was invalid: " + message);
-				return new ValidatorStatusCode(false, message);
+				return badRequest(message);
 			}
 
 
@@ -696,8 +716,7 @@ public class Download extends HttpServlet {
 				log.debug(methodName, idArrayParam + " = " + ids);
 				if (!Validator.isValidIntegerList(ids)) {
 					log.debug(methodName, idArrayParam + " was not a valid integer list.");
-					return new ValidatorStatusCode(
-							false, "The given list of ids contained one or more invalid integers");
+					return badRequest("The given list of ids contained one or more invalid integers");
 				}
 			} else {
 				String universallyUniqueId = request.getParameter(PARAM_ANON_ID);
@@ -714,13 +733,27 @@ public class Download extends HttpServlet {
 		} catch (Exception e) {
 			log.warn(e.getMessage(), e);
 		}
-		return new ValidatorStatusCode(false, "Internal error processing download request");
+		return internalServerError("Internal error processing download request");
 	}
 
 	private static ValidatorStatusCode validateForAnonymousLink(
 			String universallyUniqueId, String type, HttpServletRequest request
-	) {
-		return new ValidatorStatusCode(true);
+	) throws SQLException {
+		switch (type) {
+		case R.SOLVER:
+		case R.SOLVER_SOURCE:
+			if (AnonymousLinks.getIdOfSolverAssociatedWithLink(universallyUniqueId).isPresent()) {
+				return new ValidatorStatusCode(true);
+			}
+			return notFound("Solver not found.");
+		case R.BENCHMARK:
+			if (AnonymousLinks.getIdOfBenchmarkAssociatedWithLink(universallyUniqueId).isPresent()) {
+				return new ValidatorStatusCode(true);
+			}
+			return notFound("Benchmark not found.");
+		default:
+			return forbidden("Anonymous downloads are not supported for this download type.");
+		}
 	}
 
 	private static ValidatorStatusCode validateForUser(int userId, String type, HttpServletRequest request) {
@@ -729,7 +762,7 @@ public class Download extends HttpServlet {
 		if (!Validator.isValidPosInteger(request.getParameter(PARAM_ID))) {
 			final String message = "The given id was not a valid integer";
 			log.debug(methodName, "Download request validation failed: " + message);
-			return new ValidatorStatusCode(false, message);
+			return badRequest(message);
 		}
 
 		int id = Integer.parseInt(request.getParameter(PARAM_ID));
@@ -748,7 +781,7 @@ public class Download extends HttpServlet {
 		case R.SPACE:
 		case R.PROCESSOR:
 			if (!Permissions.canUserSeeSpace(id, userId)) {
-				return new ValidatorStatusCode(false, "You do not have permission to see this space");
+				return forbidden("You do not have permission to see this space");
 			}
 			break;
 		case R.JOB:
@@ -802,12 +835,20 @@ public class Download extends HttpServlet {
 		boolean success;
 		String shortName = null;
 		try {
+			if (request.getParameter(PARAM_ANON_ID) != null && request.getParameter(PARAM_ID) != null) {
+				response.sendError(
+						HttpServletResponse.SC_BAD_REQUEST,
+						"Invalid request: cannot combine anonId with sequential id"
+				);
+				return;
+			}
+
 			ValidatorStatusCode status = validateRequest(request);
 			if (!status.isSuccess()) {
 				log.debug("Bad download Request--" + status.getMessage());
 				//attach the message as a cookie so we don't need to be parsing HTML in StarexecCommand
 				response.addCookie(new Cookie(R.STATUS_MESSAGE_COOKIE, status.getMessage()));
-				response.sendError(HttpServletResponse.SC_BAD_REQUEST, status.getMessage());
+				response.sendError(getValidationFailureStatus(status), status.getMessage());
 				return;
 			}
 


### PR DESCRIPTION
## Summary
- block unauthenticated sequential-ID access to secure user/job/solver detail pages
- add filter-level protection for /secure/details/{user,job,solver}.jsp when anonId is absent
- add JSP-level defense-in-depth guards before data retrieval
- preserve existing anonId anonymous link behavior for job/solver pages

## Verification
- Built on se-m1 with: ant war
- Deployed to active Tomcat path: /project/apache-tomcat-7/webapps/starexec.war
- Verified app root: http://localhost:8080/starexec/ -> HTTP 200 OK
- Verified unauthenticated sequential-ID endpoints return HTTP 403:
  - http://localhost:8080/starexec/secure/details/user.jsp?id=1
  - http://localhost:8080/starexec/secure/details/job.jsp?id=1
  - http://localhost:8080/starexec/secure/details/solver.jsp?id=1
  - https://localhost/starexec/secure/details/user.jsp?id=1
  - https://localhost/starexec/secure/details/job.jsp?id=1
  - https://localhost/starexec/secure/details/solver.jsp?id=1

## Operational notes
- Production DB credential source was updated separately on se-m1 to restore app startup after WAR rebuild; no credentials are included in this PR.
- Follow-up recommended: audit all sequential integer-ID endpoints and migrate public/share links to opaque tokens or UUIDs.