### PR TITLE
fix(auth): extend WEB-H-01 IDOR auth guards

### DIFF
--- a/src/org/starexec/app/RESTServices.java
+++ b/src/org/starexec/app/RESTServices.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
@@ -5020,12 +5021,21 @@ public class RESTServices {
 	@GET
 	@Path("/reports/past/{reportName}")
 	@Produces("text/plain")
-	public String getPastReport(@PathParam("reportName") String reportName, @Context HttpServletRequest request) {
+	public Response getPastReport(@PathParam("reportName") String reportName, @Context HttpServletRequest request) {
+		int userId = SessionUtil.getUserId(request);
+		if (userId == R.PUBLIC_USER_ID) {
+			return Response.status(Response.Status.FORBIDDEN)
+					.entity(gson.toJson(new ValidatorStatusCode(false,
+							"Authentication is required to access report data.")))
+					.type("application/json")
+					.build();
+		}
+
 		try {
 			File pastReport = new File(R.STAREXEC_DATA_DIR, "/reports/" + reportName);
-			return FileUtils.readFileToString(pastReport, "UTF8");
+			return Response.ok(FileUtils.readFileToString(pastReport, "UTF8"), "text/plain").build();
 		} catch (IOException e) {
-			return "Could not get file.";
+			return Response.ok("Could not get file.", "text/plain").build();
 		}
 	}
 

--- a/src/org/starexec/app/SessionFilter.java
+++ b/src/org/starexec/app/SessionFilter.java
@@ -68,11 +68,11 @@ public class SessionFilter implements Filter {
 	}
 
 	/**
-	 * Returns true for sequential-ID detail/download resources that must never be served
-	 * to anonymous/no-principal requests. Explicit anonymous-link detail flows use
-	 * anonId without a sequential id and are intentionally excluded to preserve existing
-	 * functionality. Download requests with anonId are passed to Download for UUID/type
-	 * validation before any object is served.
+	 * Returns true for protected detail, explore, and download resources that must
+	 * never be served to anonymous/no-principal requests. Explicit anonymous-link
+	 * detail flows use anonId without a sequential id and are intentionally excluded
+	 * to preserve existing functionality. Download requests with anonId are passed
+	 * to Download for UUID/type validation before any object is served.
 	 *
 	 * @param request HTTP request
 	 * @return true when the request requires an authenticated principal
@@ -81,12 +81,33 @@ public class SessionFilter implements Filter {
 		String requestUri = request.getRequestURI();
 		boolean isUserDetailPage = requestUri.endsWith("/secure/details/user.jsp");
 		boolean isAnonymousLinkDetailPage = requestUri.endsWith("/secure/details/job.jsp") ||
-				requestUri.endsWith("/secure/details/solver.jsp");
-		boolean isDownloadEndpoint = requestUri.endsWith("/secure/download");
+				requestUri.endsWith("/secure/details/solver.jsp") ||
+				requestUri.endsWith("/secure/details/benchmark.jsp");
+		boolean isProtectedDetailPage = requestUri.endsWith("/secure/details/spaces.jsp") ||
+				requestUri.endsWith("/secure/details/community.jsp") ||
+				requestUri.endsWith("/secure/details/cluster.jsp") ||
+				requestUri.endsWith("/secure/details/configuration.jsp") ||
+				requestUri.endsWith("/secure/details/conflictingBenchmarks.jsp") ||
+				requestUri.endsWith("/secure/details/conflictingSolvers.jsp") ||
+				requestUri.endsWith("/secure/details/jobAttributes.jsp") ||
+				requestUri.endsWith("/secure/details/jobMatrixView.jsp") ||
+				requestUri.endsWith("/secure/details/jobPanelView.jsp") ||
+				requestUri.endsWith("/secure/details/pair.jsp") ||
+				requestUri.endsWith("/secure/details/pairsInSpace.jsp") ||
+				requestUri.endsWith("/secure/details/solverComparison.jsp") ||
+				requestUri.endsWith("/secure/details/solverconfigs.jsp") ||
+				requestUri.endsWith("/secure/details/XMLuploadStatus.jsp") ||
+				requestUri.endsWith("/secure/details/uploadStatus.jsp");
+		boolean isProtectedExplorePage = requestUri.endsWith("/secure/explore/statistics.jsp") ||
+				requestUri.endsWith("/secure/explore/reports.jsp") ||
+				requestUri.endsWith("/secure/explore/communities.jsp") ||
+				requestUri.endsWith("/secure/explore/spaces.jsp") ||
+				requestUri.endsWith("/secure/explore/cluster.jsp");
+		boolean isDownloadEndpoint = requestUri.contains("/secure/download");
 		boolean hasAnonId = request.getParameter("anonId") != null;
 		boolean hasSequentialId = request.getParameter("id") != null;
 
-		if (isUserDetailPage) {
+		if (isUserDetailPage || isProtectedDetailPage || isProtectedExplorePage) {
 			return true;
 		}
 
@@ -180,7 +201,7 @@ public class SessionFilter implements Filter {
 				}
 
 				if (requiresAuthenticatedPrincipal(httpRequest)) {
-					log.warn(method, "Rejecting unauthenticated sequential-ID details request: " + httpRequest.getRequestURI());
+					log.warn(method, "Rejecting unauthenticated protected resource request: " + httpRequest.getRequestURI());
 					httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Authentication is required to access this resource.");
 					return;
 				}


### PR DESCRIPTION
## Summary
Emergency WEB-H-01 IDOR remediation follow-up for the remaining Mandiant-confirmed unauthenticated data exposure paths.

## Remediation applied
- Extends `SessionFilter.requiresAuthenticatedPrincipal()` to block unauthenticated requests for:
  - Mandiant Group A detail pages: spaces, community, cluster
  - Mandiant Group B explore pages: statistics, reports, communities, spaces
  - Download servlet path matching via `/secure/download`
  - Additional same-pattern sensitive `/secure/details/*` pages found during the sweep
- Preserves existing anonymous-link flows for job, solver, and benchmark pages when `anonId` is used without a sequential `id`.
- Adds an in-method auth guard to `/services/reports/past/{reportName}` returning HTTP 403 for unauthenticated requests.

## Files changed
- `src/org/starexec/app/SessionFilter.java` — expands protected resource detection for unauthenticated requests.
- `src/org/starexec/app/RESTServices.java` — changes past report endpoint to return `Response` and enforce authentication before reading report files.

## Verification
- Remote se-m1 Ant build with this patch applied completed successfully:
  - `ant -f /home/tomcat/StarExec-Deploy/build.xml build`
  - Result: `BUILD SUCCESSFUL`
  - Included Java compile, JSP compile, WAR packaging, and existing unit tests.
- Local Ant build is blocked by local environment only: missing `/project/apache-tomcat-7/lib`.

## Deployment note
Deployment/restart is pending and will be performed manually on se-m1 after merge/pull.
